### PR TITLE
Fix iOS notifications: request permission at launch and add Pomodoro …

### DIFF
--- a/feature/pomodoro/src/iosMain/kotlin/com/habitao/feature/pomodoro/timer/IosTimerController.kt
+++ b/feature/pomodoro/src/iosMain/kotlin/com/habitao/feature/pomodoro/timer/IosTimerController.kt
@@ -10,6 +10,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import platform.UserNotifications.UNMutableNotificationContent
+import platform.UserNotifications.UNNotificationRequest
+import platform.UserNotifications.UNNotificationSound
+import platform.UserNotifications.UNTimeIntervalNotificationTrigger
+import platform.UserNotifications.UNUserNotificationCenter
 
 /**
  * iOS implementation of [TimerController] that runs the countdown timer
@@ -21,6 +26,8 @@ class IosTimerController(
 ) : TimerController {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var timerJob: Job? = null
+    private val center = UNUserNotificationCenter.currentNotificationCenter()
+    private val notificationId = "pomodoro_timer_complete"
 
     override fun start() {
         // Initialize timer if starting from scratch
@@ -36,26 +43,31 @@ class IosTimerController(
         }
 
         timerStateHolder.updateTimerState(TimerState.RUNNING)
+        scheduleCompletionNotification(timerStateHolder.remainingSeconds.value)
         scheduleCountdown()
     }
 
     override fun pause() {
         timerJob?.cancel()
+        cancelCompletionNotification()
         timerStateHolder.updateTimerState(TimerState.PAUSED)
     }
 
     override fun resume() {
         timerStateHolder.updateTimerState(TimerState.RUNNING)
+        scheduleCompletionNotification(timerStateHolder.remainingSeconds.value)
         scheduleCountdown()
     }
 
     override fun stop() {
         timerJob?.cancel()
+        cancelCompletionNotification()
         timerStateHolder.resetTimerState()
     }
 
     override fun skip() {
         timerJob?.cancel()
+        cancelCompletionNotification()
         timerStateHolder.updateTimerState(TimerState.FINISHED)
     }
 
@@ -63,6 +75,10 @@ class IosTimerController(
         val current = timerStateHolder.remainingSeconds.value
         val adjusted = (current + deltaSeconds).coerceAtLeast(0L)
         timerStateHolder.updateRemainingSeconds(adjusted)
+        // Reschedule notification with updated time
+        if (timerStateHolder.timerState.value == TimerState.RUNNING) {
+            scheduleCompletionNotification(adjusted)
+        }
     }
 
     private fun scheduleCountdown() {
@@ -79,5 +95,32 @@ class IosTimerController(
                     timerStateHolder.updateRemainingSeconds(remaining - 1L)
                 }
             }
+    }
+
+    private fun scheduleCompletionNotification(remainingSeconds: Long) {
+        cancelCompletionNotification()
+        if (remainingSeconds <= 0L) return
+
+        val sessionType = timerStateHolder.currentSessionType.value
+        val (title, body) = when (sessionType) {
+            PomodoroType.WORK -> "Focus session complete!" to "Great work! Time for a break."
+            PomodoroType.SHORT_BREAK -> "Short break over!" to "Ready to focus again?"
+            PomodoroType.LONG_BREAK -> "Long break over!" to "Feeling refreshed? Let's get back to work."
+        }
+
+        val content = UNMutableNotificationContent().apply {
+            setTitle(title)
+            setBody(body)
+            setSound(UNNotificationSound.defaultSound())
+        }
+        val trigger = UNTimeIntervalNotificationTrigger.triggerWithTimeInterval(
+            remainingSeconds.toDouble(), repeats = false
+        )
+        val request = UNNotificationRequest.requestWithIdentifier(notificationId, content, trigger)
+        center.addNotificationRequest(request, null)
+    }
+
+    private fun cancelCompletionNotification() {
+        center.removePendingNotificationRequestsWithIdentifiers(listOf(notificationId))
     }
 }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -5,6 +5,7 @@ import UserNotifications
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, _ in }
         return true
     }
 


### PR DESCRIPTION
…completion alerts

- Request UNUserNotificationCenter authorization in AppDelegate at app launch so the permission dialog appears on first run instead of waiting for a habit to be scheduled
- Schedule a UNTimeIntervalNotificationTrigger in IosTimerController when a Pomodoro session starts/resumes, and cancel it on pause/stop/skip, so session-complete notifications are delivered even when the app is backgrounded