### PR TITLE
Update TodaySummaryWidget to use ComponentName for activity actions

### DIFF
--- a/system/widget/src/main/java/com/habitao/system/widget/TodaySummaryWidget.kt
+++ b/system/widget/src/main/java/com/habitao/system/widget/TodaySummaryWidget.kt
@@ -1,7 +1,7 @@
 package com.habitao.system.widget
 
+import android.content.ComponentName
 import android.content.Context
-import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import androidx.glance.GlanceModifier
@@ -23,7 +23,7 @@ private const val MainActivityClass = "com.habitao.app.MainActivity"
 class TodaySummaryWidget : GlanceAppWidget() {
     override suspend fun provideGlance(
         context: Context,
-        id: androidx.glance.appwidget.GlanceId,
+        id: androidx.glance.GlanceId,
     ) {
         provideContent {
             TodaySummaryWidgetContent()
@@ -39,7 +39,7 @@ private fun TodaySummaryWidgetContent() {
                 .fillMaxSize()
                 .padding(12.dp)
                 .clickable(
-                    actionStartActivity(Intent().setClassName(MainActivityPackage, MainActivityClass)),
+                    actionStartActivity(ComponentName(MainActivityPackage, MainActivityClass)),
                 ),
         verticalAlignment = Alignment.Vertical.CenterVertically,
         horizontalAlignment = Alignment.Horizontal.Start,

--- a/system/widget/src/main/res/xml/today_summary_widget_info.xml
+++ b/system/widget/src/main/res/xml/today_summary_widget_info.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- 30 minutes keeps this simple summary reasonably fresh without aggressive wakeups. -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:minWidth="180dp"
     android:minHeight="90dp"
-    <!-- 30 minutes keeps this simple summary reasonably fresh without aggressive wakeups. -->
     android:updatePeriodMillis="1800000"
     android:initialLayout="@layout/today_summary_widget_initial"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
- Replace Intent with ComponentName in `actionStartActivity` for better Glance compatibility
- Fix GlanceId import by using the base `androidx.glance.GlanceId`
- Move XML comment in `today_summary_widget_info.xml` to fix potential parsing issues